### PR TITLE
unsubscribe with blank message body instead of "all"

### DIFF
--- a/user_pinger.py
+++ b/user_pinger.py
@@ -257,7 +257,7 @@ class UserPinger(object):
                 continue
             try:
                 unsub_group_msg: str = self._command_link("^^Click ^^here ^^to ^^unsubscribe ^^from ^^{group}", "unsubscribe", "{group}")
-                unsub_all_msg: str = self._command_link("^^Click ^^here ^^to ^^unsubscribe ^^from ^^all ^^groups", "unsubscribe", "all")
+                unsub_all_msg: str = self._command_link("^^Click ^^here ^^to ^^unsubscribe ^^from ^^all ^^groups", "unsubscribe", "")
                 self.reddit.redditor(user).message(
                     subject=f"You've been pinged by /u/{comment.author} in group {group}",
                     message=f"[Click here to view the comment](https://www.reddit.com{str(comment.permalink)}?context=1000)\n\n---\n\n{unsub_group_msg}\n\n{unsub_all_msg}"
@@ -411,14 +411,14 @@ class UserPinger(object):
 
             Usage:
             subject = unsubscribe
-            body = group name, "all"
+            body = group_name, ""
             """
             self.logger.debug("Getting groups")
             groups: ConfigParser = self._get_wiki_page(["config", "groups"])
             self.logger.debug("Got groups")
 
             for (group_name, username) in groups.items():
-                if (body == "all" or body == group_name)
+                if (body == "" or body == group_name)
                     if str(author) == username:
                         self.logger.debug("Removing {username} from {group_name}")
                         groups.remove_option(group_name, username)


### PR DESCRIPTION
Allows unsubscription from all groups with a blank message rather than "all"