### PR TITLE
Improvements to group name parsing

### DIFF
--- a/user_pinger.py
+++ b/user_pinger.py
@@ -208,16 +208,14 @@ class UserPinger(object):
         except ValueError:
             # no trigger
             return
-        else:
-            self.logger.debug("Ping found in %s", str(comment))
-            try:
-                trigger: str = split[index + 1]
-            except IndexError:
-                self.logger.debug("End of comment with no group specified")
-                return
-            else:
-                self.logger.debug("Found group is %s", trigger)
-                self.handle_ping(trigger, comment)
+        self.logger.debug("Ping found in %s", str(comment))
+        try:
+            trigger: str = split[index + 1]
+        except IndexError:
+            self.logger.debug("End of comment with no group specified")
+            return
+        self.logger.debug("Found group is %s", trigger)
+        self.handle_ping(trigger, comment)
 
     def handle_ping(self, group: str, comment: praw.models.Comment) -> None:
         """handles ping"""

--- a/user_pinger.py
+++ b/user_pinger.py
@@ -238,6 +238,7 @@ class UserPinger(object):
         ret, msg = self._validate_group_name(trigger)
         if not ret:
             self.logger.debug(msg)
+            self._send_error_pm(f"Invalid group name", [f"The group name {trigger} contains invalid characters"], comment.author)
             return
 
         self.logger.debug("Pinging group %s", trigger)

--- a/user_pinger.py
+++ b/user_pinger.py
@@ -590,7 +590,7 @@ class UserPinger(object):
             if self.group_exists(body, groups) is True:
                 self.logger.warning("Attempted to make group that already exists")
                 return
-            self.logger.debug("Group exists")
+            self.logger.debug("Group does not exist")
 
             self.logger.debug("Creating group %s", body.upper())
             groups.add_section(body.upper())

--- a/user_pinger.py
+++ b/user_pinger.py
@@ -607,7 +607,9 @@ class UserPinger(object):
             Moderator will be a member of the group
             """
             group_name: str = body.upper()
-            ret: bool, msg: Optional[str] = self._validate_group_name(group_name)
+            ret: bool
+            msg: Optional[str]
+            ret, msg = self._validate_group_name(group_name)
             if not ret:
                 self.logger.warning(msg)
                 self._send_pm("Cannot create group", [msg], author)

--- a/user_pinger.py
+++ b/user_pinger.py
@@ -233,7 +233,9 @@ class UserPinger(object):
         trigger: str = token.strip(self.GROUP_STRIP_PUNCT)
 
         # Validate group name to save having to look up invalid names
-        ret: bool, msg: Optional[str] = self._validate_group_name(trigger)
+        ret: bool
+        msg: Optional[str]
+        ret, msg = self._validate_group_name(trigger)
         if not ret:
             self.logger.debug(msg)
             return
@@ -698,4 +700,3 @@ class UserPinger(object):
             public_commands[command](data, author)
 
         return
-


### PR DESCRIPTION
```
Fix thinko in create_group() log message
```

```
Simplify try..except..else clauses
The `else:` case is not required since we already `return` in the
`except:`case.
```

```
Strip leading and trailing punctuations from group pings
This has been happening for a while, and most recently at:
```
https://www.reddit.com/comments/ieys9l//g2kgaqj

Fixes https://github.com/neoliberal/user_pinger/issues/11

```
Validate group names when creating and pinging
This is to ensure that we don't accidentally start using punctuation
in the group names, which will interact badly with the 'strip
punctuation' logic.

We can always expand this list later if we want to use other characters.
```